### PR TITLE
fix: correctly decode ktime

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - Compared to Tetragon, it has a smaller binary size (because it's written in Rust)
 
 ## Progress
-![](https://geps.dev/progress/7)
+![](https://geps.dev/progress/8)
 ### Done
 - Simple Process Lifecycle Monitoring
 

--- a/tetragon/src/bin/tetra.rs
+++ b/tetragon/src/bin/tetra.rs
@@ -36,6 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let event = response.event.unwrap();
         match &event {
             Event::ProcessExec(process_exec) => {
+                debug!("process_exec: {:?}", process_exec);
                 println!(
                     "🚀 process\t{}: {}: {} {}",
                     process_exec.process.as_ref().unwrap().pid.unwrap(),
@@ -45,6 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 );
             }
             Event::ProcessExit(process_exit) => {
+                debug!("process_exit: {:?}", process_exit);
                 println!(
                     "💥 exit\t\t{}: {}: {} {}",
                     process_exit.process.as_ref().unwrap().pid.unwrap(),

--- a/tetragon/src/ktime/mod.rs
+++ b/tetragon/src/ktime/mod.rs
@@ -1,0 +1,39 @@
+use prost_types::Timestamp;
+use std::time::{Duration, SystemTime};
+use tracing::*;
+
+fn decode_ktime(ktime: u64) -> Option<SystemTime> {
+    let uptime = std::fs::read_to_string("/proc/uptime").ok()?;
+    let uptime_secs: f64 = uptime.split_whitespace().next()?.parse().ok()?;
+    let boottime = SystemTime::now() - Duration::from_secs_f64(uptime_secs);
+
+    Some(boottime + Duration::from_nanos(ktime))
+}
+
+pub fn to_proto_opt(ktime: u64) -> Timestamp {
+    match decode_ktime(ktime) {
+        Some(decoded_time) => decoded_time.into(),
+        None => {
+            warn!("Failed to decode ktime: {}", ktime);
+            SystemTime::now().into()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Utc};
+
+    #[test]
+    fn test_proto_timestamp() -> anyhow::Result<()> {
+        let ktime = 73119868981932;
+        let proto_timestamp = to_proto_opt(ktime);
+        println!("Protobuf Timestamp: {:?}", proto_timestamp);
+
+        let datetime: DateTime<Utc> = SystemTime::try_from(proto_timestamp)?.into();
+        println!("UTC: {}", datetime);
+
+        Ok(())
+    }
+}

--- a/tetragon/src/lib.rs
+++ b/tetragon/src/lib.rs
@@ -7,3 +7,4 @@ pub mod api {
     #![allow(clippy::all)]
     tonic::include_proto!("tetragon");
 }
+pub mod ktime;


### PR DESCRIPTION
tetra output
```
2025-02-20T14:14:17.903617Z DEBUG tetra: process_exec: ProcessExec { process: Some(Process { exec_id: "bm9kZW5hbWU6NzYyMjIyOTUwOTYwNDg6MTU3MDYz", pid: Some(157063), uid: Some(502), cwd: "foo", binary: "/usr/bin/sleep", arguments: "1", flags: "16385", start_time: Some(Timestamp { seconds: 1740060857, nanos: 904638178 }), auid: Some(502), pod: Some(Pod { namespace: "", name: "", container: None, pod_labels: {}, workload: "", workload_kind: "" }), docker: "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", parent_exec_id: "bm9kZW5hbWU6NzYyMjIyODg0NjY1ODA6MTU3MDU2", refcnt: 0, cap: None, ns: None, tid: Some(157063), process_credentials: None, binary_properties: None, user: None }), parent: None, ancestors: [] }
```